### PR TITLE
Pass props to other type of serializers

### DIFF
--- a/src/blocksToVue.js
+++ b/src/blocksToVue.js
@@ -28,7 +28,7 @@ function blocksToVue(createElement, options) {
         vueProps = data.mark
       } else {
         // If rendering a node, also pass options and original node
-        vueProps = data.node
+        vueProps = data.node || data
         sanityProps._sanityProps = {
           node: data.node,
           options: data.options


### PR DESCRIPTION
Fix https://github.com/rdunk/sanity-blocks-vue-component/issues/16

Unless i'm wrong, right now there's no way to access props on other serializers then `Blocks` or `Marks`.

If i'm creating a `List` serializers, I can't differentiate between bullets or numbers (or any custom list type) because I don't have access to the `type` props.